### PR TITLE
Refresh Token 생성용 API 추가

### DIFF
--- a/src/controllers/sign/sign.controller.ts
+++ b/src/controllers/sign/sign.controller.ts
@@ -32,4 +32,12 @@ export class SignController {
   getPayload(@Request() req) {
     return req.user;
   }
+
+  @ApiOperation({ summary: '새로운 JWT 토큰 생성 (인증 필요)' })
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard)
+  @Get('refresh')
+  getRefreshToken(@Request() req) {
+    return this.authService.getToken(req.user);
+  }
 }


### PR DESCRIPTION
## 설명
- Token 만료시간이 60초이기 때문에 정상적으로 서비스를 사용할려면 주기적으로 API Token을 재발급 받아야 합니다.
- API Token 재발급 할 때 마다 사용자 Username과 Password를 서버로 전송하면 보안이 취약해 질 수 있습니다.
- 때문에 기존 Token으로 새로운 Token을 발행해 주는 API를 만들었습니다.

## Changes
- [x] `/api/sign/refresh` API 추가